### PR TITLE
remove extra AND operation in conversion from 8bit to 16bit

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -26,14 +26,12 @@ int is_half_carry_sub(uint8_t a, uint8_t b) {
 
 
 uint16_t get_16bit_value(uint8_t upper, uint8_t lower) {
-    /* 
-     * genereate the 16bit value from the values in two registers from upper and lower
+    /*
+     * generate the 16bit value from the values in two registers from upper and lower
      * if upper is FF and lower is 00, return value would be 0xFF00
      */
 
-    // NOTE - might be getting endianness confused! TODO check this
-
-    return (upper << 8) | (lower & 0xFF);
+    return (upper << 8) | lower;
 }
 
 uint8_t get_upper_8bit_value(uint16_t value) {


### PR DESCRIPTION
Was looking thru the sauce and found a TODO in `helper.c` :

```
uint16_t get_16bit_value(uint8_t upper, uint8_t lower) {
    /* 
     * genereate the 16bit value from the values in two registers from upper and lower
     * if upper is FF and lower is 00, return value would be 0xFF00
     */

    // NOTE - might be getting endianness confused! TODO check this

    return (upper << 8) | (lower & 0xFF);
}
```

Is the expression `(lower & 0xFF)` necessary? If I use your example inputs, 0xFF << 8 == 0xFF00.

0xFF00 | 0x00 = 0xFF00. 
I might be wrong here :sweat_smile: . Found a decent reference here: https://www.badprog.com/c-type-converting-two-uint8-t-words-into-one-of-uint16-t-and-one-of-uint16-t-into-two-of-uint8-t